### PR TITLE
Fix typo in registration filter documentation

### DIFF
--- a/data/wiki/inscriptions/index.md
+++ b/data/wiki/inscriptions/index.md
@@ -8,8 +8,7 @@ Lister et administrer les inscriptions au club.
 
 ## Gestion des inscriptions
 
-Afficher la liste des inscriptions en fonction du filtre.
-
+Afficher la liste des inscriptions en fonction des filtres.
 ### Filtres
 
 * **3 séances en cours** : membre inscrit pour la première fois au club, ayant participé à **moins de 3 séances**.


### PR DESCRIPTION
Changed "du filtre" to "des filtres" in data/wiki/inscriptions/index.md to match plural usage.

Fixes #346